### PR TITLE
Cleanup compiler warnings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,11 +78,11 @@ stages:
           install-sudo: pacman -Sy --noconfirm sudo
           prepare-env: sudo pacman -Sy --noconfirm python python-pip gcc
           pip-command: pip
-        #CentOS:
-        #  dockerImage: centos
-        #  install-sudo: yum install -y sudo
-        #  prepare-env: sudo yum install -y python3 gcc gcc-c++
-        #  pip-command: pip3
+        CentOS:
+          dockerImage: centos
+          install-sudo: yum install -y sudo
+          prepare-env: sudo yum install -y python3 gcc gcc-c++
+          pip-command: pip3
         Debian:
           dockerImage: debian
           install-sudo: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo
@@ -113,6 +113,7 @@ stages:
 - stage: publish
   displayName: publish conan package
   dependsOn: build
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
   jobs:
     - job: PublishPackage
       pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,11 +78,11 @@ stages:
           install-sudo: pacman -Sy --noconfirm sudo
           prepare-env: sudo pacman -Sy --noconfirm python python-pip gcc
           pip-command: pip
-        CentOS:
-          dockerImage: centos
-          install-sudo: yum install -y sudo
-          prepare-env: sudo yum install -y python3 gcc gcc-c++
-          pip-command: pip3
+#        CentOS:
+#          dockerImage: centos
+#          install-sudo: yum install -y sudo
+#          prepare-env: sudo yum install -y python3 gcc gcc-c++
+#          pip-command: pip3
         Debian:
           dockerImage: debian
           install-sudo: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 # https://docs.microsoft.com/de-de/azure/devops/pipelines/agents/hosted?view=azure-devops#software
-trigger:
-- master
+#trigger:
+#- master
 pr:
 - master
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -81,7 +81,7 @@ class VCVRackSDKConan(ConanFile):
 
         if self.settings.os == "Macos":
             self.cpp_info.cxxflags.append("-DARCH_MAC")
-            self.cpp_info.exelinkflags.append("-undefined dynamic_lookup") 
+            self.cpp_info.sharedlinkflags.append("-undefined dynamic_lookup")
         else:
             self.cpp_info.cxxflags.append("-Wsuggest-override")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -80,8 +80,9 @@ class VCVRackSDKConan(ConanFile):
             self.cpp_info.cxxflags.append("-DARCH_LIN")
 
         if self.settings.os == "Macos":
-            self.cpp_info.cxxflags.append("-DARCH_MAC")
-            self.cpp_info.sharedlinkflags.append("-undefined dynamic_lookup")
+            self.cpp_info.cxxflags.append("-DARCH_MAC -DIAM_CXXFLAG")
+            self.cpp_info.sharedlinkflags.append("-undefined dynamic_lookup -DIAM_FROM_SHAREDLINKFLAG")
+            self.cpp_info.exelinkflags.append("-undefined dynamic_lookup -DIAM_FROM_EXELINKFLAG")
         else:
             self.cpp_info.cxxflags.append("-Wsuggest-override")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -80,9 +80,11 @@ class VCVRackSDKConan(ConanFile):
             self.cpp_info.cxxflags.append("-DARCH_LIN")
 
         if self.settings.os == "Macos":
-            self.cpp_info.cxxflags.append("-DARCH_MAC -DIAM_CXXFLAG")
-            self.cpp_info.sharedlinkflags.append("-undefined dynamic_lookup -DIAM_FROM_SHAREDLINKFLAG")
-            self.cpp_info.exelinkflags.append("-undefined dynamic_lookup -DIAM_FROM_EXELINKFLAG")
+            self.cpp_info.cxxflags.append("-DARCH_MAC -aa IAM_CXXFLAG")
+            self.cpp_info.sharedlinkflags = []
+            self.cpp_info.sharedlinkflags.append("-undefined dynamic_lookup -xx FROM_SHAREDLINKFLAG")
+            self.cpp_info.exelinkflags = []
+            self.cpp_info.exelinkflags.append("-undefined dynamic_lookup -yy FROM_EXELINKFLAG")
         else:
             self.cpp_info.cxxflags.append("-Wsuggest-override")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -80,7 +80,7 @@ class VCVRackSDKConan(ConanFile):
             self.cpp_info.cxxflags.append("-DARCH_LIN")
 
         if self.settings.os == "Macos":
-            self.cpp_info.cxxflags.append("-DARCH_MAC -aa IAM_CXXFLAG")
+            self.cpp_info.cxxflags.append("-DARCH_MAC -DCXXFLAGS")
             self.cpp_info.sharedlinkflags = []
             self.cpp_info.sharedlinkflags.append("-undefined dynamic_lookup -xx FROM_SHAREDLINKFLAG")
             self.cpp_info.exelinkflags = []

--- a/conanfile.py
+++ b/conanfile.py
@@ -80,11 +80,9 @@ class VCVRackSDKConan(ConanFile):
             self.cpp_info.cxxflags.append("-DARCH_LIN")
 
         if self.settings.os == "Macos":
-            self.cpp_info.cxxflags.append("-DARCH_MAC -DCXXFLAGS")
-            self.cpp_info.sharedlinkflags = []
-            self.cpp_info.sharedlinkflags.append("-undefined dynamic_lookup -xx FROM_SHAREDLINKFLAG")
-            self.cpp_info.exelinkflags = []
-            self.cpp_info.exelinkflags.append("-undefined dynamic_lookup -yy FROM_EXELINKFLAG")
+            self.cpp_info.cxxflags.append("-DARCH_MAC")
+            if self.settings.compiler == "apple-clang":
+                self.cpp_info.cxxflags.append("-undefined dynamic_lookup -Wno-unused-command-line-argument")
         else:
             self.cpp_info.cxxflags.append("-Wsuggest-override")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -80,7 +80,8 @@ class VCVRackSDKConan(ConanFile):
             self.cpp_info.cxxflags.append("-DARCH_LIN")
 
         if self.settings.os == "Macos":
-            self.cpp_info.cxxflags.append("-DARCH_MAC -undefined dynamic_lookup")
+            self.cpp_info.cxxflags.append("-DARCH_MAC")
+            self.cpp_info.exelinkflags.append("-undefined dynamic_lookup") 
         else:
             self.cpp_info.cxxflags.append("-Wsuggest-override")
 
@@ -186,4 +187,3 @@ class VSCMakeSettings(Generator):
                       "type": varType
                    }
         return variable
-

--- a/test_package/plugintest.cpp
+++ b/test_package/plugintest.cpp
@@ -43,14 +43,13 @@ class TestWidget : public rack::ModuleWidget
 
   TestWidget(TestModule* module) : ModuleWidget(), _module(module)
   {
-    setModule(module);
+    setModule(_module);
   }
 
   virtual ~TestWidget() = default;
 
   void step() override
   {
-    _module->process(ProcessArgs{});
     ModuleWidget::step();
   }
 

--- a/test_package/plugintest.cpp
+++ b/test_package/plugintest.cpp
@@ -50,6 +50,7 @@ class TestWidget : public rack::ModuleWidget
 
   void step() override
   {
+    _module->process(ProcessArgs{});
     ModuleWidget::step();
   }
 


### PR DESCRIPTION
Remove compiler warnings for MacOS caused by `-undefined dynamic_lookup` compiler flag.
Remove unused variable warning in plugintest.